### PR TITLE
Laravel540RedisSentinelManager resolve name parameter set to null it …

### DIFF
--- a/src/Manager/Laravel540RedisSentinelManager.php
+++ b/src/Manager/Laravel540RedisSentinelManager.php
@@ -31,7 +31,7 @@ class Laravel540RedisSentinelManager extends VersionedRedisSentinelManager
      * @throws InvalidArgumentException If the specified connection is not
      * defined in the configuration
      */
-    protected function resolve($name)
+    protected function resolve($name = null)
     {
         return $this->resolveConnection($name);
     }


### PR DESCRIPTION
Laravel540RedisSentinelManager resolve name parameter set to null, because it extends RedisManager  